### PR TITLE
fix(timeline): position now indicator within month slots

### DIFF
--- a/premium/packages/preact-scheduler/src/timeline/TimelineCoords.ts
+++ b/premium/packages/preact-scheduler/src/timeline/TimelineCoords.ts
@@ -1,7 +1,7 @@
 import {
   DateEnv,
   DateMarker,
-  isInt
+  isInt,
 } from '@fullcalendar/preact/protected-api'
 import { TimelineDateProfile } from './timeline-date-profile'
 
@@ -14,11 +14,26 @@ For WHOLE-DAY axes only. Timed axes use computeMsSlotCoverage instead.
 Returned value is between 0 and the number of snaps.
 */
 export function computeDateSnapCoverage(date: DateMarker, tDateProfile: TimelineDateProfile, dateEnv: DateEnv): number {
-  let snapDiff = dateEnv.countDurationsBetween(
-    tDateProfile.normalizedRange.start,
-    date,
-    tDateProfile.snapDuration,
-  )
+  let snapDiff
+
+  if (tDateProfile.largeUnit) {
+    const slotStart = dateEnv.startOf(date, tDateProfile.largeUnit)
+    const slotIndex = dateEnv.countDurationsBetween(
+      tDateProfile.normalizedRange.start,
+      slotStart,
+      tDateProfile.slotDuration,
+    )
+    const slotEnd = dateEnv.add(slotStart, tDateProfile.slotDuration)
+    const slotProgress = (date.valueOf() - slotStart.valueOf()) / (slotEnd.valueOf() - slotStart.valueOf())
+
+    snapDiff = (slotIndex + slotProgress) * tDateProfile.snapsPerSlot
+  } else {
+    snapDiff = dateEnv.countDurationsBetween(
+      tDateProfile.normalizedRange.start,
+      date,
+      tDateProfile.snapDuration,
+    )
+  }
 
   if (snapDiff < 0) {
     return 0

--- a/premium/packages/vanilla-scheduler-tests/src/timeline/timeline-nowIndicator.ts
+++ b/premium/packages/vanilla-scheduler-tests/src/timeline/timeline-nowIndicator.ts
@@ -110,6 +110,18 @@ describe('timeline now-indicator', () => {
     })
   })
 
+  it('positions correctly within a month-interval cell', async () => {
+    let calendar = initCalendar({
+      initialView: 'timelineYear',
+      slotDuration: { months: 1 },
+      initialDate: '2020-08-06',
+      now: '2020-08-06',
+    })
+
+    await waitTimeout()
+    nowIndicatorRendersAt(calendar, '2020-08-06')
+  })
+
   function nowIndicatorRendersAt(calendar, date, thresh = PIXEL_THRESHOLD) {
     // wish threshold could do a smaller default threshold, but RTL messing up
 


### PR DESCRIPTION
## Summary

Fixes [fullcalendar/fullcalendar#7132](https://github.com/fullcalendar/fullcalendar/issues/7132).

With month-sized Timeline slots, `computeDateSnapCoverage` estimates positions through `countDurationsBetween`. Because calendar months have different lengths, that elapsed-time estimate can place a date inside the following month slot, which puts the `nowIndicator` in the wrong month.

For calendar-unit slots, this uses the slot start to calculate the slot index and interpolates the date's progress through the actual calendar slot. The existing duration-based path remains unchanged for other whole-day axes.