### PR TITLE
Feat/event content resource

### DIFF
--- a/premium/packages/preact-scheduler/src/ambient.ts
+++ b/premium/packages/preact-scheduler/src/ambient.ts
@@ -23,6 +23,12 @@ declare module '@fullcalendar/preact/public-api' {
     resource?: ResourceApi
   }
 
+  // the resource of the column the event is being rendered in.
+  // only populated by vertical-resource views (resourceTimeGrid).
+  interface EventDisplayInfo {
+    resource?: ResourceApi
+  }
+
   interface EventDropInfo {
     oldResource?: ResourceApi
     newResource?: ResourceApi

--- a/premium/packages/preact-scheduler/src/resource-timeline/components/ResourcePrintRow.tsx
+++ b/premium/packages/preact-scheduler/src/resource-timeline/components/ResourcePrintRow.tsx
@@ -120,6 +120,7 @@ export class ResourcePrintRow extends TimelinePrintRenderer<ResourcePrintRowProp
       todayRange: props.todayRange,
       eventSelection: slicedProps.eventSelection,
       resourceId: resource.id,
+      extraRenderProps: { resource: renderProps.resource },
     }
 
     return (

--- a/premium/packages/preact-scheduler/src/resource-timeline/components/lane/ResourceLane.tsx
+++ b/premium/packages/preact-scheduler/src/resource-timeline/components/lane/ResourceLane.tsx
@@ -168,6 +168,7 @@ export class ResourceLane extends BaseComponent<ResourceLaneProps> {
                 eventResize={slicedProps.eventResize}
                 eventSelection={slicedProps.eventSelection}
                 resourceId={resource.id}
+                extraRenderProps={{ resource: renderProps.resource }}
 
                 // dimensions
                 slotWidth={props.slotWidth}

--- a/premium/packages/preact-scheduler/src/timeline/components/TimelineEvent.tsx
+++ b/premium/packages/preact-scheduler/src/timeline/components/TimelineEvent.tsx
@@ -1,7 +1,8 @@
-import { MinimalEventProps, BaseComponent, createFormatter, StandardEvent } from '@fullcalendar/preact/protected-api'
+import { Dictionary, MinimalEventProps, BaseComponent, createFormatter, StandardEvent } from '@fullcalendar/preact/protected-api'
 
 export interface TimelineEventProps extends MinimalEventProps {
   isTimeScale: boolean
+  extraRenderProps?: Dictionary // so can include a resource
 }
 
 const DEFAULT_TIME_FORMAT = createFormatter({

--- a/premium/packages/preact-scheduler/src/timeline/components/TimelineFg.tsx
+++ b/premium/packages/preact-scheduler/src/timeline/components/TimelineFg.tsx
@@ -2,6 +2,7 @@ import { joinClassNames } from '@fullcalendar/preact/public-api'
 import {
   BaseComponent, memoize,
   getEventRangeMeta, DateMarker, DateRange, DateProfile, sortEventSegs,
+  Dictionary,
   RefMap,
   afterSize,
   EventRangeProps,
@@ -39,6 +40,7 @@ export interface TimelineFgProps {
   eventResize: EventSegUiInteractionState<TimelineRange> | null
   eventSelection: string
   resourceId?: string // hack
+  extraRenderProps?: Dictionary // so can include a resource
 
   // dimensions
   slotWidth: number | undefined
@@ -188,6 +190,7 @@ export class TimelineFg extends BaseComponent<TimelineFgProps, TimelineFgState> 
                 isResizing={isResizing}
                 isMirror={false}
                 isSelected={isSelected}
+                extraRenderProps={props.extraRenderProps}
                 {...getEventRangeMeta(eventRange, props.todayRange, props.nowDate, props.nowMs)}
               />
             </MeasuredAbsoluteHarness>
@@ -243,6 +246,7 @@ export class TimelineFg extends BaseComponent<TimelineFgProps, TimelineFgState> 
             isResizing={isResizing}
             isMirror
             isSelected={isSelected}
+            extraRenderProps={props.extraRenderProps}
             {...getEventRangeMeta(eventRange, props.todayRange, props.nowDate, props.nowMs)}
           />
         </MeasuredAbsoluteHarness>
@@ -276,6 +280,7 @@ export class TimelineFg extends BaseComponent<TimelineFgProps, TimelineFgState> 
               eventResize={props.eventResize}
               eventSelection={props.eventSelection}
               resourceId={props.resourceId}
+              extraRenderProps={props.extraRenderProps}
             />
           </MeasuredAbsoluteHarness>
         ))}

--- a/premium/packages/preact-scheduler/src/timeline/components/TimelineLaneMoreLink.tsx
+++ b/premium/packages/preact-scheduler/src/timeline/components/TimelineLaneMoreLink.tsx
@@ -1,5 +1,5 @@
 import {
-  BaseComponent, DateMarker, DateProfile, DateRange, EventRangeProps, EventSegUiInteractionState, getEventRangeMeta, MoreLinkContainer
+  BaseComponent, DateMarker, DateProfile, DateRange, Dictionary, EventRangeProps, EventSegUiInteractionState, getEventRangeMeta, MoreLinkContainer
 } from '@fullcalendar/preact/protected-api'
 import { TimelineRange } from '../TimelineLaneSlicer'
 import { TimelineEvent } from './TimelineEvent'
@@ -17,6 +17,7 @@ export interface TimelineLaneMoreLinkProps {
   eventResize: EventSegUiInteractionState<TimelineRange> | null
   eventSelection: string
   resourceId?: string // HACK... make a generic keyval like renderProps
+  extraRenderProps?: Dictionary // so can include a resource
 }
 
 export class TimelineLaneMoreLink extends BaseComponent<TimelineLaneMoreLinkProps> {
@@ -59,6 +60,7 @@ export class TimelineLaneMoreLink extends BaseComponent<TimelineLaneMoreLinkProp
                     isResizing={isResizing}
                     isMirror={false}
                     isSelected={instanceId === props.eventSelection}
+                    extraRenderProps={props.extraRenderProps}
                     {...getEventRangeMeta(eventRange, props.todayRange, props.nowDate, props.nowMs)}
                   />
                 </div>

--- a/premium/packages/preact-scheduler/src/timeline/components/TimelinePrintFg.tsx
+++ b/premium/packages/preact-scheduler/src/timeline/components/TimelinePrintFg.tsx
@@ -3,6 +3,7 @@ import {
   DateMarker,
   DateProfile,
   DateRange,
+  Dictionary,
   EventRangeProps,
   getEventRangeMeta,
   PrintEventBand,
@@ -29,6 +30,7 @@ export interface TimelinePrintFgProps {
   fgEventSegs: (TimelineRange & EventRangeProps)[]
   eventSelection: string
   resourceId?: string
+  extraRenderProps?: Dictionary // so can include a resource
 
   // dimensions
   slotWidth: number | undefined
@@ -57,6 +59,7 @@ export class TimelinePrintFg extends TimelinePrintRenderer<TimelinePrintFgProps>
             todayRange={props.todayRange}
             eventSelection={props.eventSelection}
             resourceId={props.resourceId}
+            extraRenderProps={props.extraRenderProps}
           />
         ))}
         {moreLinkBand && (
@@ -70,6 +73,7 @@ export class TimelinePrintFg extends TimelinePrintRenderer<TimelinePrintFgProps>
             todayRange={props.todayRange}
             eventSelection={props.eventSelection}
             resourceId={props.resourceId}
+            extraRenderProps={props.extraRenderProps}
           />
         )}
       </div>
@@ -85,6 +89,7 @@ interface TimelinePrintBandBaseProps {
   todayRange: DateRange
   eventSelection: string
   resourceId?: string
+  extraRenderProps?: Dictionary // so can include a resource
 }
 
 export interface TimelinePrintEventBandProps extends TimelinePrintBandBaseProps {
@@ -128,6 +133,7 @@ export function TimelinePrintEventBand(props: TimelinePrintEventBandProps) {
               isResizing={false}
               isMirror={false}
               isSelected={isSelected}
+              extraRenderProps={props.extraRenderProps}
               {...getEventRangeMeta(eventRange, props.todayRange, props.nowDate, props.nowMs)}
             />
           </MeasuredAbsoluteHarness>
@@ -172,6 +178,7 @@ export function TimelinePrintMoreLinkBand(props: TimelinePrintMoreLinkBandProps)
             eventResize={null}
             eventSelection={props.eventSelection}
             resourceId={props.resourceId}
+            extraRenderProps={props.extraRenderProps}
           />
         </MeasuredAbsoluteHarness>
       ))}

--- a/premium/packages/vanilla-scheduler-tests/src/column/column-event-render.ts
+++ b/premium/packages/vanilla-scheduler-tests/src/column/column-event-render.ts
@@ -306,5 +306,96 @@ describe('vresource event rendering', () => {
       })
       expect($('.event1').length).toBe(1)
     })
+
+    // https://github.com/fullcalendar/fullcalendar/issues/4926
+    it('gives eventContent the resource of the column being rendered', () => {
+      const resourceIds: string[] = []
+      initCalendar({
+        initialView: 'resourceTimeGridDay',
+        eventContent(arg) {
+          const id = arg.resource ? arg.resource.id : '(none)'
+          if (!resourceIds.includes(id)) { // hook can fire again on re-render
+            resourceIds.push(id)
+          }
+        },
+      })
+      expect(resourceIds.sort()).toEqual(['a', 'b'])
+    })
+
+    it('gives eventClass the resource of the column being rendered', () => {
+      initCalendar({
+        initialView: 'resourceTimeGridDay',
+        eventClass(arg) {
+          return arg.resource ? `res-${arg.resource.id}` : 'res-none'
+        },
+      })
+      expect($('.res-a').length).toBe(1)
+      expect($('.res-b').length).toBe(1)
+      expect($('.res-none').length).toBe(0)
+    })
+
+    it('leaves eventContent without a resource in a non-resource view', () => {
+      let callCnt = 0
+      let sawResource = false
+      initCalendar({
+        initialView: 'timeGridTwoDay',
+        views: {
+          timeGridTwoDay: {
+            type: 'timeGrid',
+            duration: { days: 2 },
+          },
+        },
+        eventContent(arg) {
+          callCnt += 1
+          if (arg.resource !== undefined) {
+            sawResource = true
+          }
+        },
+      })
+      expect(callCnt).toBeGreaterThan(0)
+      expect(sawResource).toBe(false)
+    })
+
+    it('gives eventContent the resource in resourceDayGrid', () => {
+      const resourceIds: string[] = []
+      initCalendar({
+        initialView: 'resourceDayGridDay',
+        eventContent(arg) {
+          const id = arg.resource ? arg.resource.id : '(none)'
+          if (!resourceIds.includes(id)) {
+            resourceIds.push(id)
+          }
+        },
+      })
+      expect(resourceIds.sort()).toEqual(['a', 'b'])
+    })
+  })
+
+  // the all-day lane of resourceTimeGrid is a DayGrid row, a separate code path
+  // from the timed columns
+  describe('with an all-day event with multiple resources', () => {
+    pushOptions({
+      events: [{
+        title: 'all day 1',
+        className: 'allday1',
+        start: '2015-11-17',
+        allDay: true,
+        resourceIds: ['a', 'b'],
+      }],
+    })
+
+    it('gives eventContent the resource in the resourceTimeGrid all-day lane', () => {
+      const resourceIds: string[] = []
+      initCalendar({
+        initialView: 'resourceTimeGridDay',
+        eventContent(arg) {
+          const id = arg.resource ? arg.resource.id : '(none)'
+          if (!resourceIds.includes(id)) {
+            resourceIds.push(id)
+          }
+        },
+      })
+      expect(resourceIds.sort()).toEqual(['a', 'b'])
+    })
   })
 })

--- a/premium/packages/vanilla-scheduler-tests/src/timeline/timeline-event-rendering.ts
+++ b/premium/packages/vanilla-scheduler-tests/src/timeline/timeline-event-rendering.ts
@@ -805,4 +805,54 @@ describe('timeline event rendering', () => { // TAKE A REALLY LONG TIME B/C SO M
     expect(emptyLaneHeight).toBe(timelineGridWrapper.getResourceLaneEl('b').offsetHeight)
     expect(emptyLaneHeight).toBeLessThan(tallLaneHeight)
   })
+
+  // https://github.com/fullcalendar/fullcalendar/issues/4926
+  describe('with an event shared by multiple resources', () => {
+    it('gives eventContent the resource of the lane being rendered', () => {
+      const resourceIds: string[] = []
+      initCalendar({
+        initialView: 'resourceTimelineDay',
+        now: '2015-11-17',
+        resources: [
+          { id: 'a', title: 'Resource A' },
+          { id: 'b', title: 'Resource B' },
+        ],
+        events: [{
+          title: 'shared',
+          start: '2015-11-17T02:00:00',
+          end: '2015-11-17T06:00:00',
+          resourceIds: ['a', 'b'],
+        }],
+        eventContent(arg) {
+          const id = arg.resource ? arg.resource.id : '(none)'
+          if (!resourceIds.includes(id)) { // hook can fire again on re-render
+            resourceIds.push(id)
+          }
+        },
+      })
+      expect(resourceIds.sort()).toEqual(['a', 'b'])
+    })
+
+    it('leaves eventContent without a resource in a non-resource timeline', () => {
+      let callCnt = 0
+      let sawResource = false
+      initCalendar({
+        initialView: 'timelineDay',
+        now: '2015-11-17',
+        events: [{
+          title: 'plain',
+          start: '2015-11-17T02:00:00',
+          end: '2015-11-17T06:00:00',
+        }],
+        eventContent(arg) {
+          callCnt += 1
+          if (arg.resource !== undefined) {
+            sawResource = true
+          }
+        },
+      })
+      expect(callCnt).toBeGreaterThan(0)
+      expect(sawResource).toBe(false)
+    })
+  })
 })

--- a/standard/packages/preact/src/common/StandardEvent.tsx
+++ b/standard/packages/preact/src/common/StandardEvent.tsx
@@ -8,6 +8,7 @@ import { EventDef } from '../structs/event-def'
 import { EventInstance } from '../structs/event-instance'
 import { EventImpl } from '../api/EventImpl'
 import { ViewContext } from '../ViewContext'
+import { Dictionary } from '../options'
 import { joinClassNames } from '../util/html'
 import classNames from '../styles.module.css'
 import { isPropsEqualShallow } from '../util/object'
@@ -42,6 +43,7 @@ export interface StandardEventProps {
   forcedTimeText?: string
   disableLiquid?: boolean // for inner-element
   disableZindexes?: boolean
+  extraRenderProps?: Dictionary // so can include a resource
 }
 
 export class StandardEvent extends BaseComponent<StandardEventProps> {
@@ -75,13 +77,15 @@ export class StandardEvent extends BaseComponent<StandardEventProps> {
     const eventApi = this.buildPublicEvent(context, eventRange.def, eventRange.instance)
     const isDraggable = !props.disableDragging && computeEventRangeDraggable(eventRange, context)
     const isBlock = /row|column/.test(props.display)
-    const subcontentRenderProps = { // TODO: spread with renderProps?
+    const subcontentRenderProps = {
+      ...props.extraRenderProps,
       event: eventApi,
       isNarrow: props.isNarrow || false,
       isShort: props.isShort || false,
       timeText,
     }
     const renderProps: EventDisplayInfo = {
+      ...props.extraRenderProps, // spread first; built-in fields below always win
       event: eventApi, // make stable. everything else atomic. FYI, eventRange unfortunately gets reconstructed a lot, but def/instance is stable
       view: context.viewApi,
       timeText: timeText,
@@ -295,7 +299,7 @@ export class StandardEvent extends BaseComponent<StandardEventProps> {
 }
 
 StandardEvent.addPropsEquality({
-  seg: isPropsEqualShallow,
+  extraRenderProps: isPropsEqualShallow,
 })
 
 function renderInnerContent(innerProps: EventDisplayInfo) {

--- a/standard/packages/preact/src/component-util/event-rendering.ts
+++ b/standard/packages/preact/src/component-util/event-rendering.ts
@@ -279,6 +279,7 @@ export interface EventDisplayInfo { // for *Content handlers
   titleClass: string
 
   options: { eventOverlap: boolean }
+  [extraProp: string]: any // so can include a resource
 }
 
 export function computeEventRangeDraggable(eventRange: EventRenderRange, context: ViewContext) {

--- a/standard/packages/preact/src/daygrid/components/DayGridCell.tsx
+++ b/standard/packages/preact/src/daygrid/components/DayGridCell.tsx
@@ -195,6 +195,7 @@ export class DayGridCell extends DateComponent<DayGridCellProps> {
                     : `.${classNames.internalView}`
                 }
                 dateSpanProps={props.dateSpanProps}
+                renderProps={props.renderProps}
                 dateProfile={props.dateProfile}
                 eventSelection={props.eventSelection}
                 eventDrag={props.eventDrag}

--- a/standard/packages/preact/src/daygrid/components/DayGridMoreLink.tsx
+++ b/standard/packages/preact/src/daygrid/components/DayGridMoreLink.tsx
@@ -19,6 +19,7 @@ export interface DayGridMoreLinkProps {
   alignElRef: RefObject<HTMLElement>
   alignParentTop: string // for popover
   dateSpanProps?: Dictionary
+  renderProps?: Dictionary // so can include a resource; forwarded to popover event content
   dateProfile: DateProfile
   todayRange: DateRange
   eventSelection: string
@@ -73,6 +74,7 @@ export class DayGridMoreLink extends BaseComponent<DayGridMoreLinkProps> {
                     isSelected={instanceId === props.eventSelection}
                     defaultTimeFormat={DEFAULT_TABLE_EVENT_TIME_FORMAT}
                     defaultDisplayEventEnd={false}
+                    extraRenderProps={props.renderProps}
                     {...getEventRangeMeta(eventRange, props.todayRange)}
                   />
                 </div>

--- a/standard/packages/preact/src/daygrid/components/DayGridRow.tsx
+++ b/standard/packages/preact/src/daygrid/components/DayGridRow.tsx
@@ -469,6 +469,8 @@ export class DayGridRow extends BaseComponent<DayGridRowProps> {
         defaultDisplayEventEnd={props.cells.length === 1}
         disableResizing={isListItem}
         forcedTimeText={props.cellIsMicro ? '' : undefined}
+        // the seg spans columns, so the resource comes from its start-column's cell
+        extraRenderProps={props.cells[range.start]?.renderProps}
         {...getEventRangeMeta(eventRange, props.todayRange)}
       />
     )

--- a/standard/packages/preact/src/timegrid/components/TimeGridCol.tsx
+++ b/standard/packages/preact/src/timegrid/components/TimeGridCol.tsx
@@ -270,6 +270,7 @@ export class TimeGridCol extends BaseComponent<TimeGridColProps> {
           isNarrow={props.isNarrow}
           isShort={segVertical.isShort || false}
           isLiquid
+          extraRenderProps={props.renderProps}
           {...getEventRangeMeta(eventRange, props.todayRange, props.nowDate, props.nowMs)}
         />
       </div>
@@ -302,7 +303,7 @@ export class TimeGridCol extends BaseComponent<TimeGridColProps> {
   has already been applied to the segs it was formed from
   */
   renderHiddenGroups(hiddenGroups: TimeGridSegHiddenGroup[]) {
-    let { dateSpanProps, dateProfile, todayRange, nowDate, nowMs, eventSelection, eventDrag, eventResize, isNarrow, isMicro } = this.props
+    let { dateSpanProps, renderProps, dateProfile, todayRange, nowDate, nowMs, eventSelection, eventDrag, eventResize, isNarrow, isMicro } = this.props
 
     return (
       <>
@@ -316,6 +317,7 @@ export class TimeGridCol extends BaseComponent<TimeGridColProps> {
               isNarrow={isNarrow}
               isMicro={isMicro}
               dateSpanProps={dateSpanProps}
+              renderProps={renderProps}
               dateProfile={dateProfile}
               todayRange={todayRange}
               nowDate={nowDate}
@@ -429,13 +431,14 @@ export class TimeGridCol extends BaseComponent<TimeGridColProps> {
 
 export function renderPlainFgSegs(
   sortedFgSegs: (TimeGridRange & EventRangeProps)[],
-  { todayRange, nowDate, nowMs, eventSelection, eventDrag, eventResize }: {
+  { todayRange, nowDate, nowMs, eventSelection, eventDrag, eventResize, renderProps }: {
     todayRange: DateRange
     nowDate: DateMarker
     nowMs?: number
     eventSelection: string
     eventDrag: EventSegUiInteractionState<TimeGridRange> | null
     eventResize: EventSegUiInteractionState<TimeGridRange> | null
+    renderProps?: Dictionary // so can include a resource
   },
   isMirror: boolean,
 ) {
@@ -468,6 +471,7 @@ export function renderPlainFgSegs(
               isShort={false}
               isNarrow={false}
               disableResizing
+              extraRenderProps={renderProps}
               {...getEventRangeMeta(eventRange, todayRange, nowDate, nowMs)}
             />
           </div>

--- a/standard/packages/preact/src/timegrid/components/TimeGridEvent.tsx
+++ b/standard/packages/preact/src/timegrid/components/TimeGridEvent.tsx
@@ -1,4 +1,5 @@
 import { BaseComponent } from '../../vdom-util'
+import { Dictionary } from '../../options'
 import { MinimalEventProps } from '../../component-util/event-rendering'
 import { createFormatter } from '../../datelib/formatting'
 import { StandardEvent } from '../../common/StandardEvent'
@@ -16,6 +17,7 @@ export interface TimeGridEventProps extends MinimalEventProps {
   isShort: boolean
   isLiquid?: boolean
   disableResizing?: boolean // HACK
+  extraRenderProps?: Dictionary // so can include a resource
 }
 
 export class TimeGridEvent extends BaseComponent<TimeGridEventProps> {

--- a/standard/packages/preact/src/timegrid/components/TimeGridMoreLink.tsx
+++ b/standard/packages/preact/src/timegrid/components/TimeGridMoreLink.tsx
@@ -16,6 +16,7 @@ export interface TimeGridMoreLinkProps {
   top: CssDimValue
   height: CssDimValue
   dateSpanProps?: Dictionary
+  renderProps?: Dictionary // so can include a resource; forwarded to popover event content
   dateProfile: DateProfile
   todayRange: DateRange
   nowDate: DateMarker


### PR DESCRIPTION
AI was used but i personally checked the code and verified it works

# Expose the rendered column's resource to event render hooks

Fixes https://github.com/fullcalendar/fullcalendar/issues/4926

## Problem

When an event is assigned to several resources, it renders once per resource,
but `eventContent` / `eventClass` / `eventDidMount` receive no indication of
*which* resource is being rendered. `arg.event.getResources()` returns all of
them, so rendering conditionally per resource is impossible.

## Approach

This follows the hunch on the ticket: the vertical-resource views already pass
the resource down as extra render props on the column, and those can be
forwarded to event rendering.

## Usage

```js
eventContent(arg) {
  if (arg.resource?.id === 'b') {
    return { html: `${arg.event.title} — room B only` }
  }
  return { html: arg.event.title }
}
```

`arg.resource` is a `ResourceApi`, or `undefined` in non-resource views.

## Support

| View | `arg.resource` |
| --- | --- |
| resourceTimeGrid (timed) | yes |
| resourceTimeGrid (all-day lane) | yes |
| resourceDayGrid | yes |
| resourceTimeline | yes |
| non-resource views | `undefined`, unchanged |

Covered on the normal, print/stack and "+N more" popover paths.

## Testing

- 7 new specs in `column-event-render.ts` and `timeline-event-rendering.ts`,
  covering each resource view, the all-day lane, and negative cases in
  non-resource views.